### PR TITLE
feat: pod log inquiry api implementation

### DIFF
--- a/src/app/backend/pkg/app/ack.go
+++ b/src/app/backend/pkg/app/ack.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	log "github.com/sirupsen/logrus"
 	"net/http"
+	"net/url"
 
 	"github.com/astaxie/beego/validation"
 	"github.com/gin-gonic/gin"
@@ -81,4 +82,18 @@ func (g *Gin) ValidateUrl(params []string) error {
 	}
 	return nil
 
+}
+
+// parse querystrings
+func (g *Gin) ParseQuery() (url.Values, error) {
+
+	u, err := url.Parse(g.C.Request.RequestURI)
+	if err != nil {
+		return nil, err
+	}
+	query, err := url.ParseQuery(u.RawQuery)
+	if err != nil {
+		return nil, err
+	}
+	return query, nil
 }

--- a/src/app/backend/router/apis/raw.go
+++ b/src/app/backend/router/apis/raw.go
@@ -7,13 +7,18 @@ package apis
 */
 
 import (
+	"context"
+	"io"
 	"net/http"
-	"net/url"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/kore3lab/dashboard/pkg/app"
 	"github.com/kore3lab/dashboard/pkg/config"
+	log "github.com/sirupsen/logrus"
+	coreV1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -113,8 +118,7 @@ func GetRaw(c *gin.Context) {
 	var err error
 
 	ListOptions := v1.ListOptions{}
-	u, _ := url.Parse(c.Request.RequestURI)
-	query, _ := url.ParseQuery(u.RawQuery)
+	query, _ := g.ParseQuery()
 
 	err = v1.Convert_url_Values_To_v1_ListOptions(&query, &ListOptions, nil)
 	if err != nil {
@@ -200,5 +204,95 @@ func PatchRaw(c *gin.Context) {
 	}
 
 	g.Send(http.StatusOK, r)
+
+}
+
+// Get Pod logs
+func GetPodLogs(c *gin.Context) {
+	g := app.Gin{C: c}
+
+	var err error
+
+	// url parameter validation
+	v := []string{"NAMESPACE", "NAME"}
+	if err := g.ValidateUrl(v); err != nil {
+		g.SendMessage(http.StatusBadRequest, err.Error(), err)
+		return
+	}
+
+	// instancing dynamic client
+	client, err := config.Cluster.Client(g.C.Param("CLUSTER"))
+	if err != nil {
+		g.SendMessage(http.StatusBadRequest, err.Error(), err)
+		return
+	}
+
+	apiClient, err := client.NewKubernetesClient()
+	if err != nil {
+		g.SendMessage(http.StatusBadRequest, err.Error(), err)
+		return
+	}
+
+	//  log options (with querystring)
+	options := coreV1.PodLogOptions{}
+	query, err := g.ParseQuery()
+	if err == nil {
+		if len(query) > 0 {
+			if query["container"] != nil {
+				options.Container = query["container"][0]
+			}
+			if query["follow"] != nil {
+				options.Follow, _ = strconv.ParseBool(query["follow"][0])
+			}
+			if query["previous"] != nil {
+				options.Previous, _ = strconv.ParseBool(query["previous"][0])
+			}
+		}
+	}
+
+	// get a log stream
+	req := apiClient.CoreV1().Pods(g.C.Param("NAMESPACE")).GetLogs(g.C.Param("NAME"), &options)
+	stream, err := req.Stream(context.TODO())
+	if err != nil {
+		g.SendMessage(http.StatusBadRequest, err.Error(), err)
+		return
+	}
+	defer stream.Close()
+
+	// read a stream go-routine
+	chanStream := make(chan []byte, 10)
+	go func() {
+		defer close(chanStream)
+
+		for {
+			buf := make([]byte, 4096)
+			numBytes, err := stream.Read(buf)
+
+			if err != nil {
+				if err != io.EOF {
+					log.Infof("finished log streaming (cause=%s)", err.Error())
+					return
+				} else {
+					if options.Follow == false {
+						log.Debug("log stream is EOF")
+						break
+					} else {
+						time.Sleep(time.Second * 1)
+					}
+				}
+			} else {
+				chanStream <- buf[:numBytes]
+			}
+		}
+	}()
+
+	// write stream to client
+	g.C.Stream(func(w io.Writer) bool {
+		if data, ok := <-chanStream; ok {
+			w.Write(data)
+			return true
+		}
+		return false
+	})
 
 }

--- a/src/app/backend/router/router.go
+++ b/src/app/backend/router/router.go
@@ -99,6 +99,8 @@ func CreateUrlMappings() {
 		rawAPI.DELETE("/:A/:B/:RESOURCE/:NAME", apis.DeleteRaw) // "/namespaces/:NAMESPACE/:RESOURCE/:NAME" > namespaced core apiGroup - delete
 		rawAPI.PATCH("/:A/:B/:RESOURCE/:NAME", apis.PatchRaw)   // "/namespaces/:NAMESPACE/:RESOURCE/:NAME" > namespaced core apiGroup - patch
 	}
+	// "/namespaces/:NAMESPACE/pods/:NAME/:OP" > pod operate (log,exec)
+	Router.GET("/raw/clusters/:CLUSTER/api/:VERSION/namespaces/:NAMESPACE/pods/:NAME/log", authenticate(), apis.GetPodLogs)
 
 	// RAW-API Grouped
 	//      non-Namespaced


### PR DESCRIPTION
* **Get a pod logs.**
* http://`<Backend URL>`/raw/clusters/`<Cluster Name>`/api/v1/namespaces/`<Namespace Name>`/pods/`<Pod Name>`/log?follow=`<true/false | default=false>`&container=`<Container Name | options>`&previous=`<true/false | default=false>`
* QueryString
  * container : the container for which to stream logs; defaults to only container if there is one container in the pod
  * follow : follow the log stream of the pod
  * previous : return previous terminated container logs; defaults to false
* 예
  * `curl http://localhost:3001/raw/clusters/apps-06/api/v1/namespaces/kube-system/pods/metrics-server-84b97b4d6-4gxvs/log?follow=1`
